### PR TITLE
Adds mouse up event listener to window for events outside shadow-dom.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lou-assistant/draft-js",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The tests seem to pass and fail on the same ones that occur when tested on the `master` branch.